### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/vdabtd/9527d8b4-f8a6-4521-9cc7-dfe1670cc6f4/353080e4-3d7e-4118-a628-6c35bf400c83/_apis/work/boardbadge/d7df28ad-1951-4bd1-bd39-ad83c382407c)](https://dev.azure.com/vdabtd/9527d8b4-f8a6-4521-9cc7-dfe1670cc6f4/_boards/board/t/353080e4-3d7e-4118-a628-6c35bf400c83/Microsoft.RequirementCategory)
 # This project is retired, archived, and no longer supported. You are welcome to continue to use and fork the repository.
 
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#337](https://dev.azure.com/vdabtd/9527d8b4-f8a6-4521-9cc7-dfe1670cc6f4/_workitems/edit/337). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.